### PR TITLE
fix(singleType): This currently pluralises all names even for single types.

### DIFF
--- a/.changeset/young-ways-flash.md
+++ b/.changeset/young-ways-flash.md
@@ -1,0 +1,5 @@
+---
+"@rixw/strapi-client": patch
+---
+
+Uses the passed isSingleType prop from fetchSingle to determine if should pluralise the endpoint name or not

--- a/packages/strapi-client/src/client/client.ts
+++ b/packages/strapi-client/src/client/client.ts
@@ -71,6 +71,7 @@ export class StrapiClient {
    * @param entityName - The singular name of the entity you want to query/write
    * @param id - The ID of the entity you want to query/write, or undefined
    * @param params - The params to pass to the Strapi API
+   * @param isSingleType - Whether the entity is a single type
    * @returns The endpoint URL
    */
   public getEndpoint(
@@ -81,7 +82,8 @@ export class StrapiClient {
   ): string {
     const contentType = this.entityMap.get(entityName);
     const query = qs.stringify(params, { addQueryPrefix: true, encodeValuesOnly: true });
-    return this.getUrl(`${contentType?.path}${id ? `/${id}` : ''}${query}`);
+    const path = isSingleType ? contentType?.singularName : pluralize(contentType?.singularName);
+    return this.getUrl(`/api/${path}${id ? `/${id}` : ''}${query}`);
   }
 
   /**


### PR DESCRIPTION
Single types aren't pluralised in Strapi's API so they return 404. This does make the path pluralise in getSimpleEntitySpec unnecessary; but I can't see anywhere else except in getEndpoint that isSingleType is passed across anywhere. 